### PR TITLE
Set new UUID on first boot

### DIFF
--- a/digital-ocean/configs/strapi/set-strapi-ip.sh
+++ b/digital-ocean/configs/strapi/set-strapi-ip.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-# Used to set Strapi proxy IP on first boot, you can safely delete this script
+# Used to set Strapi proxy IP and change UUID on first boot, you can safely delete this script
 SERVER=/srv/strapi/strapi/config/environments/development/server.json
+PACKAGE=/srv/strapi/strapi/package.json
 IP=$(curl -s ifconfig.me)
+UUID=$(uuidgen)
+
+if [ -f "$PACKAGE" ]; then
+  su - strapi -c "sed -i 's/\"uuid\":.*/\"uuid\": \"'$UUID'\"/g' $PACKAGE"
+  chown -R strapi:strapi /srv/strapi
+fi
 
 if [ -f "$SERVER" ]; then
   su - strapi -c "sed -i s/changeme/$IP/g $SERVER"


### PR DESCRIPTION
Updated init startup script to replace the UUID on first boot for Strapi analytics.

Not sure if this UUID matches the same version that Strapi needs