### PR TITLE
Fixing issue with Windows line returns not triggering script

### DIFF
--- a/digital-ocean/configs/strapi/set-strapi-ip.sh
+++ b/digital-ocean/configs/strapi/set-strapi-ip.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+
 # Used to set Strapi proxy IP and change UUID on first boot, you can safely delete this script
 SERVER=/srv/strapi/strapi/config/environments/development/server.json
 PACKAGE=/srv/strapi/strapi/package.json
+
 IP=$(curl -s ifconfig.me)
 UUID=$(uuidgen)
 


### PR DESCRIPTION
Yes I know it looks like I just inserted some new lines, for whatever reason the script got borked with the line endings and wasn't firing on first boot.

Note to self, we need to add pre-commit hooks into this repo to resolve any line ending issues.